### PR TITLE
initial version command for colony cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work.sum
 
 # env file
 .env
+tmp/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -extldflags "-static"
+      - -X github.com/konstructio/colony/configs.Version=v{{.Version}}
 
 archives:
   - format: tar.gz

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,6 @@ func GetRootCommand() *cobra.Command {
 		SilenceErrors: true, // we print the errors ourselves on main
 	}
 
-	cmd.AddCommand(getInitCommand())
+	cmd.AddCommand(getInitCommand(), getVersionCommand())
 	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/konstructio/colony/configs"
+	"github.com/konstructio/colony/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+func getVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "print the version for colony cli",
+		Long:  `print the version for colony cli`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log := logger.New(logger.Debug)
+
+			log.Info("colony cli version: ", configs.Version)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,0 +1,12 @@
+package configs
+
+const (
+	DefaultVersion = "development"
+)
+
+//nolint:gochecknoglobals // used to store the version of the built binary
+var Version = DefaultVersion
+
+type Config struct {
+	Version string
+}


### PR DESCRIPTION
## Description
`colony version` needs to exist

## Related Issue(s)
Fixes # FLY-49

## How to test
```
go run . version
# produces `development`

goreleaser build --snapshot --clean --single-target
./dist/colony_darwin_arm64/colony version
# produces a snapshot tag with sha v0.1.0-SNAPSHOT-e909a3c

git rev-parse --short HEAD
e909a3c
# short sha of build
```
![image](https://github.com/user-attachments/assets/a325620a-810d-4593-aad2-5a6aa18febc8)
