### PR TITLE
leverage default colony url for api url flag

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -298,7 +298,6 @@ func getInitCommand() *cobra.Command {
 	cmd.Flags().StringVar(&loadBalancerIP, "load-balancer-ip", "", "the local network interface for colony to use")
 
 	cmd.MarkFlagRequired("api-key")
-	cmd.MarkFlagRequired("api-url")
 	cmd.MarkFlagRequired("load-balancer-interface")
 	cmd.MarkFlagRequired("load-balancer-ip")
 	return cmd


### PR DESCRIPTION
## Description
when the `api-url` flag is marked required it must be passed to the CLI even if we have a default value set
![image](https://github.com/user-attachments/assets/10a5baaf-7324-4d88-8e12-9f53bac6271f)


## How to test
```
go run . init \
    --api-key=$api-key \
    --load-balancer-interface=&interface \
    --load-balancer-ip=$ip
 ```
