### PR TITLE
fix: add colony api token in discovery template

### DIFF
--- a/manifests/templates/discovery.yaml
+++ b/manifests/templates/discovery.yaml
@@ -21,4 +21,5 @@ spec:
               K1_COLONY_HARDWARE_ID: "{{.colony_hardware_id}}"
               CHROOT: y
               COLONY_API_URL: "{{.colony_api_url}}"
+              COLONY_API_KEY: "{{.colony_token}}"
               COLONY_AGENT_ID: "{{.colony_agent_id}}"


### PR DESCRIPTION
## Description
This PR adds Colony API key required for discovery in the template.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
